### PR TITLE
Add support for KUBECONFIG environment variable

### DIFF
--- a/cmd/brigadeterm/flags.go
+++ b/cmd/brigadeterm/flags.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-
-	"k8s.io/client-go/util/homedir"
 )
 
 type cmdFlags struct {
@@ -25,7 +23,13 @@ func newCmdFlags() (*cmdFlags, error) {
 	return fls, err
 }
 func (c *cmdFlags) init() error {
-	kubehome := filepath.Join(homedir.HomeDir(), ".kube", "config")
+	var kubehome string
+
+	if kubehome = os.Getenv("KUBECONFIG"); kubehome == "" {
+		kubehome = filepath.Join(
+			os.Getenv("HOME"), ".kube", "config",
+		)
+	}
 
 	// register flags
 	c.fs.StringVar(&c.kubeConfig, "kubeconfig", kubehome, "kubernetes configuration path, only used when development mode enabled")

--- a/cmd/brigadeterm/flags.go
+++ b/cmd/brigadeterm/flags.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"k8s.io/client-go/util/homedir"
 )
 
 type cmdFlags struct {
@@ -26,9 +28,7 @@ func (c *cmdFlags) init() error {
 	var kubehome string
 
 	if kubehome = os.Getenv("KUBECONFIG"); kubehome == "" {
-		kubehome = filepath.Join(
-			os.Getenv("HOME"), ".kube", "config",
-		)
+		kubehome = filepath.Join(homedir.HomeDir(), ".kube", "config")
 	}
 
 	// register flags


### PR DESCRIPTION
This commit adds support for the `KUBECONFIG` environment variable.
I use this like all the time and it's the official and documented way.

This is just a feature added on top and should not break the current
(expected) behaviour.

So one could do something like this:

```bash
brigadeterm -kubeconfig /home/marco/.kube/superevil-kubeconfig.yaml -namespace brigade
```

Or one could also export it and use it right away like this:

```bash
export KUBECONFIG=/home/marco/.kube/superevil-kubeconfig.yaml
brigadeterm -namespace brigade
```
For more infos,
see: https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/#set-the-kubeconfig-environment-variable