### PR TITLE
Add filter to projects listing page

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,11 @@
 ## 0.3.0 / 2018-04-20
 
-* [ENHACEMENT] (UI) Adds Backspace to go back.
-* [ENHACEMENT] (UI) Adds R for reloading as keybinding.
-* [ENHACEMENT] (UI) Adds Q for quit as keybinding.
-* [ENHACEMENT] (k8s) Update to 0.7.0 Kubernetes go client lib.
-* [ENHACEMENT] (k8s) Load all available credential types in the Kubernetes go client lib.
-* [ENHACEMENT] (Brigade) Update to Brigade v0.13.
+* [ENHANCEMENT] (UI) Add Backspace to go back.
+* [ENHANCEMENT] (UI) Add R for reloading as keybinding.
+* [ENHANCEMENT] (UI) Add Q for quit as keybinding.
+* [ENHANCEMENT] (k8s) Update to 0.7.0 Kubernetes go client lib.
+* [ENHANCEMENT] (k8s) Load all available credential types in the Kubernetes go client lib.
+* [ENHANCEMENT] (Brigade) Update to Brigade v0.13.
 
 ## 0.2.0 / 2018-03-30
 

--- a/cmd/brigadeterm/flags.go
+++ b/cmd/brigadeterm/flags.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-
-	"k8s.io/client-go/util/homedir"
 )
 
 type cmdFlags struct {
@@ -25,7 +23,13 @@ func newCmdFlags() (*cmdFlags, error) {
 	return fls, err
 }
 func (c *cmdFlags) init() error {
-	kubehome := filepath.Join(homedir.HomeDir(), ".kube", "config")
+	var kubehome string
+
+	if kubehome = os.Getenv("KUBECONFIG"); kubehome == "" {
+		kubehome = filepath.Join(
+			os.Getenv("HOME"), ".kube", "config",
+		)
+	}
 
 	// register flags
 	c.fs.StringVar(&c.kubeConfig, "kubeconfig", kubehome, "kubernetes configuration path, only used when development mode enabled")

--- a/cmd/brigadeterm/flags.go
+++ b/cmd/brigadeterm/flags.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"k8s.io/client-go/util/homedir"
 )
 
 type cmdFlags struct {
@@ -26,9 +28,7 @@ func (c *cmdFlags) init() error {
 	var kubehome string
 
 	if kubehome = os.Getenv("KUBECONFIG"); kubehome == "" {
-		kubehome = filepath.Join(
-			os.Getenv("HOME"), ".kube", "config",
-		)
+		kubehome = filepath.Join(homedir.HomeDir(), ".kube", "config")
 	}
 
 	// register flags

--- a/pkg/ui/page/projects.go
+++ b/pkg/ui/page/projects.go
@@ -128,7 +128,7 @@ func (p *ProjectList) createComponents() {
 		SetDirection(tview.FlexRow).
 		AddItem(p.projectsTable, 0, 1, true).
 		AddItem(p.usage, 1, 1, false).
-		AddItem(p.filterInputField, 1, 1, true)
+		AddItem(p.filterInputField, 1, 1, false)
 }
 
 func (p *ProjectList) fill(ctx *controller.ProjectListPageContext) {

--- a/pkg/ui/page/projects.go
+++ b/pkg/ui/page/projects.go
@@ -108,7 +108,7 @@ func (p *ProjectList) createComponents() {
 			} else {
 				p.filterInputField.SetLabelColor(tcell.ColorYellow)
 			}
-			p.setFilter(term)
+			p.projectListFilter = term
 			p.filter()
 			p.router.app.SetFocus(p.projectsTable)
 		})
@@ -141,14 +141,6 @@ func (p *ProjectList) fillUsage() {
 	p.usage.SetText(projectListUsage)
 }
 
-func (p *ProjectList) setFilter(term string) {
-	p.projectListFilter = term
-}
-
-func (p *ProjectList) getFilter() string {
-	return p.projectListFilter
-}
-
 func (p *ProjectList) filter() {
 	p.router.LoadProjectList()
 }
@@ -168,7 +160,7 @@ func (p *ProjectList) fillProjectList(ctx *controller.ProjectListPageContext) {
 
 	// Set body.
 	rowPosition := 1
-	filter := p.getFilter()
+	filter := p.projectListFilter
 	for _, project := range ctx.Projects {
 		if project == nil {
 			continue

--- a/pkg/ui/page/projects.go
+++ b/pkg/ui/page/projects.go
@@ -19,12 +19,12 @@ const (
 	projectListUsage = `[yellow](F5) [white]Reload    [yellow](/) [white]Filter    [yellow](Q) [white]Quit`
 )
 
-var projectListFilter string
-
 // ProjectList is the main page where the project list will be available.
 type ProjectList struct {
 	controller controller.Controller
 	router     *Router
+
+	projectListFilter string
 
 	// page layout
 	layout tview.Primitive
@@ -143,52 +143,15 @@ func (p *ProjectList) fillUsage() {
 }
 
 func (p *ProjectList) setFilter(term string) {
-	projectListFilter = term
+	p.projectListFilter = term
 }
 
-func (p *ProjectList) filterSetItemVisibility(rowIndex int, visibility bool) {
-	var colIndex int
-	var colCount int
-	colCount = p.projectsTable.GetColumnCount()
-	for colIndex = 0; colIndex < colCount; colIndex++ {
-		myTCell := p.projectsTable.GetCell(rowIndex, colIndex)
-		if visibility == true {
-			myTCell.SetSelectable(true)
-		} else {
-			myTCell.SetSelectable(false)
-		}
-		if colIndex < 5 { // for everything, except the "icons"
-			if visibility == true {
-				myTCell.SetTextColor(tcell.ColorGray)
-			} else {
-				myTCell.SetTextColor(tcell.ColorBlack)
-			}
-		} else { // only for the "icons"
-			if visibility == true {
-				myTCell.SetBackgroundColor(tcell.ColorGray)
-			} else {
-				myTCell.SetBackgroundColor(tcell.ColorBlack)
-			}
-		}
-	}
+func (p *ProjectList) getFilter() string {
+	return p.projectListFilter
 }
 
 func (p *ProjectList) filter() {
-	var projectsCount int
-	var rowIndex int
-	projectsCount = p.projectsTable.GetRowCount()
-	for rowIndex = 1; rowIndex < projectsCount; rowIndex++ {
-		tableCell := p.projectsTable.GetCell(rowIndex, 1)
-		projectName := tableCell.Text
-		// hide the current row, if it does not match the
-		// projectListFilter
-		if projectListFilter != "" && strings.Contains(strings.ToLower(projectName), projectListFilter) == false {
-			p.filterSetItemVisibility(rowIndex, false)
-		} else { // show the current row
-			p.filterSetItemVisibility(rowIndex, true)
-		}
-
-	}
+	p.router.LoadProjectList()
 }
 
 func (p *ProjectList) fillProjectList(ctx *controller.ProjectListPageContext) {
@@ -206,8 +169,13 @@ func (p *ProjectList) fillProjectList(ctx *controller.ProjectListPageContext) {
 
 	// Set body.
 	rowPosition := 1
+	filter := p.getFilter()
 	for _, project := range ctx.Projects {
 		if project == nil {
+			continue
+		}
+
+		if filter != "" && strings.Contains(strings.ToLower(project.Name), filter) == false {
 			continue
 		}
 
@@ -267,5 +235,4 @@ func (p *ProjectList) fillProjectList(ctx *controller.ProjectListPageContext) {
 			p.router.LoadProjectBuildList(projectID)
 		}
 	})
-	p.filter()
 }

--- a/pkg/ui/page/projects.go
+++ b/pkg/ui/page/projects.go
@@ -126,7 +126,6 @@ func (p *ProjectList) createComponents() {
 	// Create the layout.
 	p.layout = tview.NewFlex().
 		SetDirection(tview.FlexRow).
-		// AddItem(p.projectsTable, 0, 1, true).
 		AddItem(p.projectsTable, 0, 1, true).
 		AddItem(p.usage, 1, 1, false).
 		AddItem(p.filterInputField, 1, 1, true)


### PR DESCRIPTION
This commit adds filtering to the projects list (as requested in #20) by adding these items:

- A TextInput below the usage area
- A new shortcut `/` and the respective info in the usage area
- Some helper functions
  - `focusFilterForm` (sets focus to the filter text field)
  - `setFilter` (sets the filter string `projectListFilter`)
  - `filterSetItemVisibility` (makes the items in the list "in/visible")
  - `filter` (uses `filterSetItemVisibility` based on search term)

I searched the documentation of tview, but I didn't find anything on
making stuff "invisible", so I used a workaround for this, by setting
the colors of the items to match the background, so they simply become
invisible (but still have their width and height reserved; like CSS's
`visibility:hidden`).

The filter box is "invisible" by default.
If you hit `/` it becomes "visible" and you can enter a search term and
hit enter.

The project list then becomes "filtered" by setting all times which
doesn't match the search string to "not selectable" and setting their
colors so they match the background color.

If you want to clear the "filter", you just have to make it blank and
hit enter. This is a somehow expected behaviour; at least in my
opinion. Once you made it blank and hit enter, it becomes "invisible"
again.